### PR TITLE
fix(generator): 修正发电机把带符号 EU 当作发电量读取的问题

### DIFF
--- a/src/main/java/io/github/cpearl0/ctnhcore/common/machine/multiblock/generator/ChemicalGeneratorMachine.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/common/machine/multiblock/generator/ChemicalGeneratorMachine.java
@@ -66,7 +66,7 @@ public class ChemicalGeneratorMachine extends RecipeElectricMultiblockMachine {
         if (!(machine instanceof ChemicalGeneratorMachine engineMachine)) {
             return RecipeModifier.nullWrongType(LargeCombustionEngineMachine.class, machine);
         }
-        long EUt = RecipeHelper.getRealEUtWithIO(recipe);
+        long EUt = recipe.getOutputEUt();
         // has lubricant
         if (EUt > 0) {
             int maxParallel = (int) (engineMachine.getOverclockVoltage() / EUt); // get maximum parallel

--- a/src/main/java/io/github/cpearl0/ctnhcore/common/machine/multiblock/generator/HyperPlasmaTurbineMachine.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/common/machine/multiblock/generator/HyperPlasmaTurbineMachine.java
@@ -11,7 +11,6 @@ import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
-import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.handler.RecipeHandlerGroup;
 import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
@@ -170,7 +169,7 @@ public class HyperPlasmaTurbineMachine extends MultiblockComputationMachine {
             return RecipeModifier.nullWrongType(HyperPlasmaTurbineMachine.class, machine);
         }
 
-        final long EUt = RecipeHelper.getRealEUtWithIO(recipe);
+        final long EUt = recipe.getOutputEUt();
         final long turbineMaxVoltage = hptm.getOverclockVoltage();
 
         if (EUt <= 0 || turbineMaxVoltage <= EUt) return RecipeModifier.DEFAULT_FAILURE;
@@ -215,7 +214,7 @@ public class HyperPlasmaTurbineMachine extends MultiblockComputationMachine {
 
             long maxProduction = getOverclockVoltage();
             long currentProduction = isActive() && recipeLogic.getLastRecipe() != null ?
-                    RecipeHelper.getRealEUtWithIO(recipeLogic.getLastRecipe()) : 0;
+                    recipeLogic.getLastRecipe().getOutputEUt() : 0;
 
             if (isActive()) {
                 textList.add(Component.translatable("gtceu.multiblock.turbine.energy_per_tick",

--- a/src/main/java/io/github/cpearl0/ctnhcore/common/machine/multiblock/generator/MegaTurbineMachine.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/common/machine/multiblock/generator/MegaTurbineMachine.java
@@ -10,7 +10,6 @@ import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IRotorHolderMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.RecipeElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
-import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.handler.RecipeHandlerGroup;
 import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
@@ -83,7 +82,7 @@ public class MegaTurbineMachine extends RecipeElectricMultiblockMachine implemen
         var rotorHolder = turbineMachine.getRotorHolder();
         if (rotorHolder == null) return RecipeModifier.DEFAULT_FAILURE;
 
-        long EUt = RecipeHelper.getRealEUtWithIO(recipe);
+        long EUt = recipe.getOutputEUt();
         long turbineMaxVoltage = turbineMachine.getOverclockVoltage();
         double holderEfficiency = rotorHolder.getTotalEfficiency() / 100.0;
 
@@ -130,7 +129,7 @@ public class MegaTurbineMachine extends RecipeElectricMultiblockMachine implemen
 
                 long maxProduction = getOverclockVoltage();
                 long currentProduction = isActive() && recipeLogic.getLastRecipe() != null ?
-                        RecipeHelper.getRealEUtWithIO(recipeLogic.getLastRecipe()) : 0;
+                        recipeLogic.getLastRecipe().getOutputEUt() : 0;
                 String voltageName = GTValues.VNF[GTUtil.getTierByVoltage(currentProduction)];
 
                 if (isActive()) {

--- a/src/main/java/io/github/cpearl0/ctnhcore/common/machine/multiblock/generator/WaterPowerStationMachine.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/common/machine/multiblock/generator/WaterPowerStationMachine.java
@@ -5,7 +5,6 @@ import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.CoilWorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
-import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.handler.RecipeHandlerGroup;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
 import com.gregtechceu.gtceu.common.machine.trait.multiblock.CoilMachineTrait;
@@ -65,7 +64,7 @@ public class WaterPowerStationMachine extends CoilWorkableElectricMultiblockMach
     public void addDisplayText(List<Component> textList) {
         if (isFormed()) {
             var outputEnergy = isActive() && recipeLogic.getLastRecipe() != null ?
-                    RecipeHelper.getRealEUtWithIO(recipeLogic.getLastRecipe()) : 0;
+                    recipeLogic.getLastRecipe().getOutputEUt() : 0;
             var voltageName = GTValues.VNF[GTUtil.getTierByVoltage(outputEnergy)];
             textList.add(Component.translatable("multiblock.ctnh.water_power_station1", water));
             textList.add(Component.translatable("multiblock.ctnh.water_power_station.efficiency",

--- a/src/main/java/io/github/cpearl0/ctnhcore/data/recipe/RecipeRemoval.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/data/recipe/RecipeRemoval.java
@@ -51,7 +51,6 @@ public class RecipeRemoval {
      * 最终在 {@code RecipeManagerApplyMixin} 中统一处理。
      */
     public static void init() {
-
         // ===== 外部类删除（与 RecipeRemoval 同模块/相关模块） =====
         EIORecipes.eioRemovals();
         QuantumOmniRecipes.omniRemovals();


### PR DESCRIPTION
- RecipeHelper.getRealEUtWithIO 返回带符号净 EU（发电配方为负），发电机应改用 recipe.getOutputEUt 读取发电量
- 等离子涡轮此前对所有合法配方都因 EUt <= 0 判定失败，现可正常计算并行与输出功率
- 大型涡轮与化学燃料发电机同样改用 getOutputEUt，输出功率不足的提示与产线数值恢复正确
- 水力发电站与涡轮机的 GUI 当前发电量显示恢复为正数
- 移除因此不再需要的 RecipeHelper 导入