### PR TITLE
fix(machine): 修复多方块机器未迁移到新配方基类的问题

### DIFF
--- a/src/main/java/io/github/cpearl0/ctnhcore/registry/CTNHRecipeModifiers.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/registry/CTNHRecipeModifiers.java
@@ -9,7 +9,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.machine.multiblock.CoilWorkableElectricMultiblockMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.RecipeElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.OverclockingLogic;
 import com.gregtechceu.gtceu.api.recipe.handler.RecipeHandlerGroup;
@@ -58,7 +58,7 @@ public class CTNHRecipeModifiers {
                                                   @NotNull GTRecipe recipe) {
         var coilMachine = machine.getTrait(CoilMachineTrait.class);
         if (coilMachine == null ||
-                !(machine instanceof WorkableElectricMultiblockMachine workableElectricMultiblockMachine)) {
+                !(machine instanceof RecipeElectricMultiblockMachine workableElectricMultiblockMachine)) {
             return RecipeModifier.nullWrongType(CoilWorkableElectricMultiblockMachine.class, machine);
         }
 

--- a/src/main/java/io/github/cpearl0/ctnhcore/registry/machines/multiblock/GTNNMultiblocks.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/registry/machines/multiblock/GTNNMultiblocks.java
@@ -16,7 +16,7 @@ import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
-import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.RecipeElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.pattern.FactoryBlockPattern;
 import com.gregtechceu.gtceu.api.pattern.Predicates;
 import com.gregtechceu.gtceu.api.pattern.util.RelativeDirection;
@@ -175,7 +175,7 @@ public class GTNNMultiblocks {
                         CTNHCore.id("block/casings/solid/radiation_proof_machine_casing"),
                         CTNHCore.id("block/multiblock/large_naquadah_reactor"))
                 .register();
-        LARGE_DEHYDRATOR = REGISTRATE.multiblock("large_dehydrator", WorkableElectricMultiblockMachine::new)
+        LARGE_DEHYDRATOR = REGISTRATE.multiblock("large_dehydrator", RecipeElectricMultiblockMachine::new)
                 .cnLangValue("大型脱水机")
                 .rotationState(RotationState.NON_Y_AXIS)
                 .recipeTypes(CTNHRecipeTypes.DEHYDRATOR_RECIPES)

--- a/src/main/java/io/github/cpearl0/ctnhcore/registry/machines/multiblock/MultiblocksA.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/registry/machines/multiblock/MultiblocksA.java
@@ -33,7 +33,6 @@ import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.CoilWorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.machine.multiblock.RecipeElectricMultiblockMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.pattern.FactoryBlockPattern;
 import com.gregtechceu.gtceu.api.pattern.Predicates;
 import com.gregtechceu.gtceu.api.pattern.TraceabilityPredicate;
@@ -1703,7 +1702,7 @@ public class MultiblocksA {
             .workableCasingModel(GTCEu.id("block/casings/solid/machine_casing_solid_steel"), GTCEu.id("block/multiblock/vacuum_freezer"))
             .register();
 
-    public final static MultiblockMachineDefinition PLASMA_CONDENSER = REGISTRATE.multiblock("plasma_condenser", WorkableElectricMultiblockMachine::new)
+    public final static MultiblockMachineDefinition PLASMA_CONDENSER = REGISTRATE.multiblock("plasma_condenser", RecipeElectricMultiblockMachine::new)
             .cnLangValue("等离子冷凝器")
             .rotationState(RotationState.ALL)
             .recipeType(CTNHRecipeTypes.PLASMA_CONDENSER_RECIPES)
@@ -2220,7 +2219,7 @@ public class MultiblocksA {
             .workableCasingModel(GTCEu.id("block/casings/solid/machine_casing_robust_tungstensteel"), GTCEu.id("block/multiblock/large_chemical_reactor"))
             .register();
 
-    public static final MultiblockMachineDefinition SINTERING_KILN = REGISTRATE.multiblock("sintering_kiln", WorkableElectricMultiblockMachine::new)
+    public static final MultiblockMachineDefinition SINTERING_KILN = REGISTRATE.multiblock("sintering_kiln", RecipeElectricMultiblockMachine::new)
             .cnLangValue("烧结窑")
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeType(CTNHRecipeTypes.SINTERING_KILN)
@@ -2254,7 +2253,7 @@ public class MultiblocksA {
             GTCEu.id("block/multiblock/generator/extreme_combustion_engine"),
             "无尽内燃引擎");
 
-    public static final MultiblockMachineDefinition CHEMICAL_VAPOR_DEPOSITION_MACHINE = REGISTRATE.multiblock("chemical_vapor_deposition_machine", WorkableElectricMultiblockMachine::new)
+    public static final MultiblockMachineDefinition CHEMICAL_VAPOR_DEPOSITION_MACHINE = REGISTRATE.multiblock("chemical_vapor_deposition_machine", RecipeElectricMultiblockMachine::new)
             .cnLangValue("化学气相沉积器")
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeType(CTNHRecipeTypes.CHEMICAL_VAPOR_DEPOSITION)
@@ -2375,7 +2374,7 @@ public class MultiblocksA {
             .workableCasingModel(CTNHCore.id("block/high_grade_coke_oven_bricks"), GTCEu.id("block/machines/arc_furnace"))
             .register();
 
-    public static final MultiblockMachineDefinition DIMENSIONAL_GAS_COLLECTION_CHAMBER = REGISTRATE.multiblock("dimensional_gas_collection_chamber", WorkableElectricMultiblockMachine::new)
+    public static final MultiblockMachineDefinition DIMENSIONAL_GAS_COLLECTION_CHAMBER = REGISTRATE.multiblock("dimensional_gas_collection_chamber", RecipeElectricMultiblockMachine::new)
             .cnLangValue("维度集气室")
             .rotationState(RotationState.ALL)
             .recipeType(CTNHRecipeTypes.DIMENSIONAL_GAS_COLLECTION)
@@ -2619,7 +2618,7 @@ public class MultiblocksA {
             .workableCasingModel(GTCEu.id("block/casings/gcym/corrosion_proof_casing"), GTCEu.id("block/multiblock/large_chemical_reactor"))
             .register();
 
-    public static final MultiblockMachineDefinition LARGE_STEEL_FURNACE = REGISTRATE.multiblock("large_steel_furnace", WorkableElectricMultiblockMachine::new)
+    public static final MultiblockMachineDefinition LARGE_STEEL_FURNACE = REGISTRATE.multiblock("large_steel_furnace", RecipeElectricMultiblockMachine::new)
             .cnLangValue("大型钢制熔炉")
             .rotationState(RotationState.ALL)
             .recipeType(GTRecipeTypes.FURNACE_RECIPES)
@@ -2641,7 +2640,7 @@ public class MultiblocksA {
             .workableCasingModel(GTCEu.id("block/casings/solid/machine_primitive_bricks"), GTCEu.id("block/multiblock/implosion_compressor"))
             .register();
 
-    public static final MultiblockMachineDefinition LARGE_STEEL_ALLOY_FURNACE = REGISTRATE.multiblock("large_steel_alloy_furnace", WorkableElectricMultiblockMachine::new)
+    public static final MultiblockMachineDefinition LARGE_STEEL_ALLOY_FURNACE = REGISTRATE.multiblock("large_steel_alloy_furnace", RecipeElectricMultiblockMachine::new)
             .cnLangValue("大型钢制合金炉")
             .rotationState(RotationState.ALL)
             .recipeType(GTRecipeTypes.ALLOY_SMELTER_RECIPES)
@@ -2754,7 +2753,7 @@ public class MultiblocksA {
 //                    .build())
 //            .workableCasingModel(CTNHCore.id("block/casings/osmiridium_casing"), GTCEu.id("block/multiblock/large_miner"))
 //            .register();
-    public static final MultiblockMachineDefinition DECAY_POOLS = REGISTRATE.multiblock("decay_pools_machine", WorkableElectricMultiblockMachine::new)
+    public static final MultiblockMachineDefinition DECAY_POOLS = REGISTRATE.multiblock("decay_pools_machine", RecipeElectricMultiblockMachine::new)
             .cnLangValue("衰变罐")
             .rotationState(RotationState.ALL)
             .recipeType(CTNHRecipeTypes.DECAY_POOLS)
@@ -2976,7 +2975,7 @@ public class MultiblocksA {
             .register();
 
 
-    public static final MultiblockMachineDefinition SUPER_CENTRIFUGE = REGISTRATE.multiblock("super_centrifuge", WorkableElectricMultiblockMachine::new)
+    public static final MultiblockMachineDefinition SUPER_CENTRIFUGE = REGISTRATE.multiblock("super_centrifuge", RecipeElectricMultiblockMachine::new)
             .cnLangValue("超速离心机")
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeTypes(GTRecipeTypes.CENTRIFUGE_RECIPES, CTNHRecipeTypes.DIFFERENTIAL_CENTRIFUGE_RECIPES)

--- a/src/main/java/io/github/cpearl0/ctnhcore/registry/machines/multiblock/MultiblocksB.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/registry/machines/multiblock/MultiblocksB.java
@@ -22,7 +22,7 @@ import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
-import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.RecipeElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.pattern.FactoryBlockPattern;
 import com.gregtechceu.gtceu.api.pattern.Predicates;
 import com.gregtechceu.gtceu.api.recipe.OverclockingLogic;
@@ -708,7 +708,7 @@ public class MultiblocksB {
 
 
 
-    public final static MultiblockMachineDefinition SILICA_ROCK_FUEL_REFINERY = REGISTRATE.multiblock("silica_rock_fuel_refinery", WorkableElectricMultiblockMachine::new)
+    public final static MultiblockMachineDefinition SILICA_ROCK_FUEL_REFINERY = REGISTRATE.multiblock("silica_rock_fuel_refinery", RecipeElectricMultiblockMachine::new)
             .cnLangValue("硅岩燃料精炼厂")
             .rotationState(RotationState.ALL)
             .recipeTypes(CTNHRecipeTypes.SILICA_ROCK_FUEL_REFINERY)
@@ -1211,7 +1211,7 @@ public class MultiblocksB {
                     GTCEu.id("block/multiblock/assembly_line"))
             .register();
 
-    public final static MultiblockMachineDefinition CultivationRoom = REGISTRATE.multiblock("cultivationroom", WorkableElectricMultiblockMachine::new)
+    public final static MultiblockMachineDefinition CultivationRoom = REGISTRATE.multiblock("cultivationroom", RecipeElectricMultiblockMachine::new)
             .cnLangValue("培养室")
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeType(CTNHRecipeTypes.CULTIVATION_ROOM)
@@ -1447,7 +1447,7 @@ public class MultiblocksB {
 //
 //            .workableCasingModel(CTPP.id("block/create/railway_casing"), GTCEu.id("block/multiblock/generator/large_steam_turbine"))
 //            .register();
-    public final static MultiblockMachineDefinition COMBINED_VAPOR_DEPOSITION_FACILITY = REGISTRATE.multiblock("combined_vapor_deposition_facility", WorkableElectricMultiblockMachine::new)
+    public final static MultiblockMachineDefinition COMBINED_VAPOR_DEPOSITION_FACILITY = REGISTRATE.multiblock("combined_vapor_deposition_facility", RecipeElectricMultiblockMachine::new)
             .cnLangValue("集成沉积工厂")
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeTypes(CTNHRecipeTypes.PVB_RECIPE, CTNHRecipeTypes.CHEMICAL_VAPOR_DEPOSITION)
@@ -1645,7 +1645,7 @@ public class MultiblocksB {
 
             .workableCasingModel(GTCEu.id("block/casings/hpca/high_power_casing"), GTCEu.id("block/multiblock/generator/large_steam_turbine"))
             .register();
-    public static final MultiblockMachineDefinition GAS_CENTRIFUGE = REGISTRATE.multiblock("gas_centrifuge", WorkableElectricMultiblockMachine::new)
+    public static final MultiblockMachineDefinition GAS_CENTRIFUGE = REGISTRATE.multiblock("gas_centrifuge", RecipeElectricMultiblockMachine::new)
             .cnLangValue("气体离心机")
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeType(CTNHRecipeTypes.GAS_CENTRIFUGE_RECIPES)


### PR DESCRIPTION
- 集成沉积工厂、等离子冷凝器、烧结窑、化学气相沉积器、维度集气室、超级离心机等 13 台机器的注册基类由 WorkableElectricMultiblockMachine 改为 RecipeElectricMultiblockMachine
- 上述机器此前未实现 IRecipeLogicMachine，机器模式页签不显示，无法切换配方类型，已注册的配方类型也不生效
- 修正 CTNHRecipeModifiers.ebfOverclock 中仍指向旧基类的类型判断，使线圈多方块不再被判为类型错误
- 覆盖 MultiblocksA、MultiblocksB、GTNNMultiblocks 三张注册表的 13 处注册